### PR TITLE
Applied min-price to the /gts sell <type> <price>

### DIFF
--- a/plugin-sponge/src/main/java/me/nickimpact/gts/commands/SpongeGtsCmd.java
+++ b/plugin-sponge/src/main/java/me/nickimpact/gts/commands/SpongeGtsCmd.java
@@ -35,13 +35,25 @@ public class SpongeGtsCmd extends BaseCommand {
 					if(additionals.length == 0) {
 						classification.getUi().createFor(player).getDisplay().open(player);
 					} else {
-						classification.getCmdHandler().apply(player, additionals);
+						Config config = GTS.getInstance().getConfiguration();
+						Config msgConfig = GTS.getInstance().getMsgConfig();
+						TextParsingUtils parser = GTS.getInstance().getTextParsingUtils();
+
+						if(config.get(ConfigKeys.MIN_PRICING_ENABLED)) {
+							// Should be MIN_MONEY_PRICE. Not sure where that is or if its handled elsewhere
+							if(Integer.parseInt(additionals[0]) >= config.get(ConfigKeys.MAX_MONEY_PRICE)) {
+								player.sendMessage(parser.fetchAndParseMsg(player, MsgConfigKeys.MIN_PRICE_ERROR, null, null));
+							} else {
+								classification.getCmdHandler().apply(player, additionals);
+							}
+						} else {
+							classification.getCmdHandler().apply(player, additionals);
+						}
 					}
 				}
 			}
 		}
 	}
-
 	@Subcommand("ignore")
 	@CommandPermission("gts.command.ignore.base")
 	public class IgnoreSub extends BaseCommand {


### PR DESCRIPTION
Was told there was a bug where the min price was not applied to selling when using a command. Haven't looked into the GTS source before so getting everything didn't work quite well. But this should help get the ball rolling for a good portion of the implementation.

Found some max price values in ConfigKeys but couldn't find anything regarding min-price besides the Minable interface having a method for calculating the min price. This will need to be edited but is most likely more helpful than just an issue =)